### PR TITLE
add kubernetes-helm@2.8.2.rb

### DIFF
--- a/Formula/kubernetes-helm@2.8.2.rb
+++ b/Formula/kubernetes-helm@2.8.2.rb
@@ -1,0 +1,49 @@
+class KubernetesHelmAT282 < Formula
+  desc "The Kubernetes package manager"
+  homepage "https://helm.sh/"
+  url "https://github.com/kubernetes/helm.git",
+      :tag => "v2.8.2",
+      :revision => "a80231648a1473929271764b920a8e346f6de844"
+  head "https://github.com/kubernetes/helm.git"
+
+  bottle do
+    cellar :any_skip_relocation
+    sha256 "c105b8e5e29febdaa4e71d4d418550f87d13a75d6585b84e93958c2409ef2723" => :high_sierra
+    sha256 "101dff96d86c4725437619fc8c1b3691cdcefdddfeacd230559fde2e256f479f" => :sierra
+    sha256 "ea87d059e4eadb526c3dd12857a4f07cae0080af538a656d04f6617f7cb191b1" => :el_capitan
+  end
+
+  depends_on "mercurial" => :build
+  depends_on "go" => :build
+  depends_on "glide" => :build
+
+  def install
+    ENV["GOPATH"] = buildpath
+    ENV["GLIDE_HOME"] = HOMEBREW_CACHE/"glide_home/#{name}"
+    ENV.prepend_create_path "PATH", buildpath/"bin"
+    arch = MacOS.prefer_64_bit? ? "amd64" : "x86"
+    ENV["TARGETS"] = "darwin/#{arch}"
+    dir = buildpath/"src/k8s.io/helm"
+    dir.install buildpath.children - [buildpath/".brew_home"]
+
+    cd dir do
+      system "make", "bootstrap"
+      system "make", "build"
+
+      bin.install "bin/helm"
+      bin.install "bin/tiller"
+      man1.install Dir["docs/man/man1/*"]
+      bash_completion.install "scripts/completions.bash" => "helm"
+      prefix.install_metafiles
+    end
+  end
+
+  test do
+    system "#{bin}/helm", "create", "foo"
+    assert File.directory? "#{testpath}/foo/charts"
+
+    version_output = shell_output("#{bin}/helm version --client 2>&1")
+    assert_match "GitTreeState:\"clean\"", version_output
+    assert_match stable.instance_variable_get(:@resource).instance_variable_get(:@specs)[:revision], version_output if build.stable?
+  end
+end

--- a/Formula/kubernetes-helm@2.8.2.rb
+++ b/Formula/kubernetes-helm@2.8.2.rb
@@ -6,7 +6,17 @@ class KubernetesHelmAT282 < Formula
       :revision => "a80231648a1473929271764b920a8e346f6de844"
   head "https://github.com/kubernetes/helm.git"
 
+  # force "kubernetes-helm" for bottle download
+  # https://github.com/glensc/homebrew-tap/pull/1#issuecomment-486371612
+  def name
+    "kubernetes-helm"
+  end
+
   bottle do
+    # force "bottles" subdir for download
+    # https://github.com/glensc/homebrew-tap/pull/1#issuecomment-486371612
+    root_url "https://homebrew.bintray.com/bottles"
+
     cellar :any_skip_relocation
     sha256 "c105b8e5e29febdaa4e71d4d418550f87d13a75d6585b84e93958c2409ef2723" => :high_sierra
     sha256 "101dff96d86c4725437619fc8c1b3691cdcefdddfeacd230559fde2e256f479f" => :sierra

--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
-# homebrew
-Homebrew Formulas
+# Extra Homebrew Formulas
+
+To setup use this Tap:
+```
+brew tap glensc/tap
+```
+
+Installing:
+
+```
+brew install kubernetes-helm@2.8.2
+```


### PR DESCRIPTION
created with:

```
$ brew extract kubernetes-helm glensc/tap --version=2.8.2
==> Tapping glensc/tap
Cloning into '/usr/local/Homebrew/Library/Taps/glensc/homebrew-tap'...
remote: Enumerating objects: 4, done.
remote: Counting objects: 100% (4/4), done.
remote: Compressing objects: 100% (3/3), done.
remote: Total 4 (delta 0), reused 0 (delta 0), pack-reused 0
Unpacking objects: 100% (4/4), done.
Tapped (29 files, 25.5KB).
==> Searching repository history
==> Writing formula for kubernetes-helm from revision 993e941 to /usr/local/Homebrew/Library/Taps/glensc/homebrew-tap/Formula/kubernetes-helm@2.8.2.rb
```
doc: https://docs.brew.sh/Versions