### PR TITLE
add memcache 3.0.9 extension for php 7.1

### DIFF
--- a/Formula/php@7.1-memcache.rb
+++ b/Formula/php@7.1-memcache.rb
@@ -8,7 +8,7 @@ class PhpAT71Memcache < PhpExtensionFormula
 
   def install
     system php_parent.bin/"phpize"
-    system "./configure", *configure_args
+    system "./configure", *configure_args, "--with-zlib-dir=#{Formula["zlib"].opt_prefix}"
     system "make"
     (lib/module_path).install "modules/#{extension}.so"
   end

--- a/Formula/php@7.1-memcache.rb
+++ b/Formula/php@7.1-memcache.rb
@@ -3,8 +3,8 @@ require File.expand_path("../lib/php_extension_formula", __dir__)
 class PhpAT71Memcache < PhpExtensionFormula
   extension_dsl "Memcache Extension"
 
-  url "https://github.com/websupport-sk/pecl-memcache/archive/NON_BLOCKING_IO_php7.tar.gz"
-  sha256 "8a14cb069cd8ec06db24db630c7c8405a7417b1a3d821bac34f2177ed5208439"
+  url "https://github.com/websupport-sk/pecl-memcache/archive/e702b5f91/memcache-3.0.9-e702b5f91.tar.gz"
+  sha256 "4a2b13e80074236054ee88c8461578a780d96698c86274303cb8b4b52037b759"
 
   def install
     system php_parent.bin/"phpize"

--- a/Formula/php@7.1-memcache.rb
+++ b/Formula/php@7.1-memcache.rb
@@ -1,0 +1,15 @@
+require File.expand_path("../lib/php_extension_formula", __dir__)
+
+class PhpAT71Memcache < PhpExtensionFormula
+  extension_dsl "Memcache Extension"
+
+  url "https://github.com/websupport-sk/pecl-memcache/archive/NON_BLOCKING_IO_php7.tar.gz"
+  sha256 "8a14cb069cd8ec06db24db630c7c8405a7417b1a3d821bac34f2177ed5208439"
+
+  def install
+    system php_parent.bin/"phpize"
+    system "./configure", *configure_args
+    system "make"
+    (lib/module_path).install "modules/#{extension}.so"
+  end
+end

--- a/README.md
+++ b/README.md
@@ -9,4 +9,5 @@ Installing:
 
 ```
 brew install kubernetes-helm@2.8.2
+brew install php@7.1-memcache
 ```

--- a/lib/php_extension_formula.rb
+++ b/lib/php_extension_formula.rb
@@ -1,0 +1,90 @@
+class PhpExtensionFormula < Formula
+  def initialize(*)
+    super
+    active_spec.owner = php_parent.stable.owner
+  end
+
+  def install
+    cd "ext/#{extension}"
+    system php_parent.bin/"phpize"
+    system "./configure", *configure_args
+    system "make"
+    (lib/module_path).install "modules/#{extension}.so"
+  end
+
+  def post_install
+    ext_config_path = etc/"php"/php_parent.php_version/"conf.d"/"ext-#{extension}.ini"
+    if ext_config_path.exist?
+      inreplace ext_config_path,
+        /#{extension_type}=.*$/, "#{extension_type}=#{opt_lib/module_path}/#{extension}.so"
+    else
+      ext_config_path.write <<~EOS
+        [#{extension}]
+        #{extension_type}=#{opt_lib/module_path}/#{extension}.so
+      EOS
+    end
+  end
+
+  test do
+    assert_match extension.downcase, shell_output("#{php_parent.opt_bin}/php -m").downcase,
+      "failed to find extension in php -m output"
+  end
+
+  private
+
+  delegate [ # rubocop:disable Layout/AlignHash
+    :php_parent,
+    :extension,
+    :configure_args,
+  ] => :"self.class"
+
+  def extension_type
+    # extension or zend_extension
+    "extension"
+  end
+
+  def module_path
+    extension_dir = Utils.popen_read("#{php_parent.opt_bin/"php-config"} --extension-dir").chomp
+    php_basename = File.basename(extension_dir)
+    "php/#{php_basename}"
+  end
+
+  class << self
+    NAME_PATTERN = /^Php(?:AT([57])(\d+))?(.+)/.freeze
+    attr_reader :configure_args, :php_parent, :extension
+
+    def configure_arg(args)
+      @configure_args ||= []
+      @configure_args.concat(Array(args))
+    end
+
+    def extension_dsl(description = nil)
+      class_name = name.split("::").last
+      m = NAME_PATTERN.match(class_name)
+      if m.nil?
+        raise "Bad PHP Extension name for #{class_name}"
+      elsif m[1].nil?
+        parent_name = "php"
+      else
+        parent_name = "php@" + m.captures[0..1].join(".")
+      end
+
+      @php_parent = Formula[parent_name]
+      @extension = m[3].gsub(/([a-z])([A-Z])/) do
+        Regexp.last_match(1) + "_" + Regexp.last_match(2)
+      end.downcase
+      @configure_args = %W[
+        --with-php-config=#{php_parent.opt_bin/"php-config"}
+      ]
+
+      desc "#{description} for PHP #{php_parent.php_version}" unless description.nil?
+
+      homepage php_parent.homepage + extension
+      url php_parent.stable.url
+      send php_parent.stable.checksum.hash_type, php_parent.stable.checksum.hexdigest
+
+      depends_on "autoconf" => :build
+      depends_on parent_name
+    end
+  end
+end


### PR DESCRIPTION
ported from https://github.com/kabel/homebrew-php-ext/pull/7

upstream pecl release is still work in progress: https://github.com/websupport-sk/pecl-memcache/issues/42