### PR TITLE
Add php@7.3-mcrypt

### DIFF
--- a/Formula/php@7.3-mcrypt.rb
+++ b/Formula/php@7.3-mcrypt.rb
@@ -1,0 +1,12 @@
+require_relative "../lib/php_pecl_formula"
+
+class PhpAT73Mcrypt < PhpPeclFormula
+  extension_dsl "Mcrypt Extension"
+  version "1.0.3"
+
+  url "https://pecl.php.net/get/mcrypt-1.0.3.tgz"
+  sha256 "affd675843a079e9efd49ac2f723286dd5bcb0916315aa53e2ae5edd5eadb034"
+
+  depends_on "libtool"
+  depends_on "mcrypt"
+end

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ brew install glensc/tap/php@7.1-imagick
 brew install glensc/tap/php@7.1-tideways-xhprof
 brew install glensc/tap/php@7.1-spx
 brew install glensc/tap/php@7.3-mysql
+brew install glensc/tap/php@7.3-mcrypt
 brew install glensc/tap/vcpkg
 brew cask install glensc/tap/eid-ee
 ```


### PR DESCRIPTION
Whilst [mcrypt](https://www.php.net/mcrypt) is deprecated, it might be useful to boot up old projects.

There's also polyfill which could be used alternative:
- https://github.com/phpseclib/mcrypt_compat