### PR TITLE
proxysql 1.4.9 (new formula; patches backported from pending 1.4.10)

### DIFF
--- a/Formula/proxysql.rb
+++ b/Formula/proxysql.rb
@@ -40,11 +40,11 @@ class Proxysql < Formula
   test do
     system bin/"proxysql", "--help"
     background_proxysql = fork do
-      exec "#{bin}/proxysql", "--initial"
+      exec "#{bin}/proxysql", "-S", "admin.sock"
     end
     begin
       # Sleep until the proxy is up (querying it prematurely causes a segfault), then check its uptime.
-      output = pipe_output("sleep 2; echo 'select * from stats.stats_mysql_global' | mysql -uadmin -padmin -h0.0.0.0 -P6032")
+      output = pipe_output("sleep 2; echo 'select * from stats.stats_mysql_global' | mysql -uadmin -padmin -S admin.sock")
       assert_match /ProxySQL_Uptime\s+[1-9]\d*/, output
     ensure
       Process.kill("TERM", background_proxysql)

--- a/Formula/proxysql.rb
+++ b/Formula/proxysql.rb
@@ -8,7 +8,7 @@ class Proxysql < Formula
   depends_on "automake" => :build
   depends_on "cmake" => :build
   depends_on "make" => :build
-  depends_on "mysql" => :test
+  depends_on "mysql@5.6" => :test
   depends_on "curl"
   depends_on "openssl"
 
@@ -44,7 +44,7 @@ class Proxysql < Formula
     end
     begin
       # Sleep until the proxy is up (querying it prematurely causes a segfault), then check its uptime.
-      output = pipe_output("sleep 2; echo 'select * from stats.stats_mysql_global' | mysql --enable-cleartext-plugin  --default-auth=mysql_clear_password -uadmin -padmin -S admin.sock")
+      output = pipe_output("sleep 2; echo 'select * from stats.stats_mysql_global' | mysql -uadmin -padmin -S admin.sock")
       assert_match /ProxySQL_Uptime\s+[1-9]\d*/, output
     ensure
       Process.kill("TERM", background_proxysql)

--- a/Formula/proxysql.rb
+++ b/Formula/proxysql.rb
@@ -44,7 +44,7 @@ class Proxysql < Formula
     end
     begin
       # Sleep until the proxy is up (querying it prematurely causes a segfault), then check its uptime.
-      output = pipe_output("sleep 2; echo 'select * from stats.stats_mysql_global' | mysql -uadmin -padmin -S admin.sock")
+      output = pipe_output("sleep 2; echo 'select * from stats.stats_mysql_global' | mysql --enable-cleartext-plugin  --default-auth=mysql_clear_password -uadmin -padmin -S admin.sock")
       assert_match /ProxySQL_Uptime\s+[1-9]\d*/, output
     ensure
       Process.kill("TERM", background_proxysql)

--- a/Formula/proxysql.rb
+++ b/Formula/proxysql.rb
@@ -44,7 +44,7 @@ class Proxysql < Formula
     end
     begin
       # Sleep until the proxy is up (querying it prematurely causes a segfault), then check its uptime.
-      output = pipe_output("sleep 2; echo 'select * from stats.stats_mysql_global' | mysql -uadmin -padmin -S admin.sock")
+      output = pipe_output("sleep 2; echo 'select * from stats.stats_mysql_global' | $(brew --prefix mysql@5.6)/bin/mysql -uadmin -padmin -S admin.sock")
       assert_match /ProxySQL_Uptime\s+[1-9]\d*/, output
     ensure
       Process.kill("TERM", background_proxysql)

--- a/Formula/proxysql.rb
+++ b/Formula/proxysql.rb
@@ -44,7 +44,7 @@ class Proxysql < Formula
     end
     begin
       # Sleep until the proxy is up (querying it prematurely causes a segfault), then check its uptime.
-      output = pipe_output("sleep 2; mysql -uadmin -padmin -S admin.sock stats < <( echo 'select * from stats.stats_mysql_global' )")
+      output = pipe_output("sleep 2; echo 'select * from stats.stats_mysql_global' | mysql -uadmin -padmin -S admin.sock")
       assert_match /ProxySQL_Uptime\s+[1-9]\d*/, output
     ensure
       Process.kill("TERM", background_proxysql)

--- a/Formula/proxysql.rb
+++ b/Formula/proxysql.rb
@@ -44,7 +44,7 @@ class Proxysql < Formula
     end
     begin
       # Sleep until the proxy is up (querying it prematurely causes a segfault), then check its uptime.
-      output = pipe_output("sleep 2; echo 'select * from stats.stats_mysql_global' | mysql -uadmin -padmin -S admin.sock")
+      output = pipe_output("sleep 2; mysql -uadmin -padmin -S admin.sock stats < <( echo 'select * from stats.stats_mysql_global' )")
       assert_match /ProxySQL_Uptime\s+[1-9]\d*/, output
     ensure
       Process.kill("TERM", background_proxysql)

--- a/Formula/proxysql.rb
+++ b/Formula/proxysql.rb
@@ -1,31 +1,15 @@
 class Proxysql < Formula
-  desc "General-purpose data compression with high compression ratio"
+  desc "High Performance Advanced Proxy for MySQL"
   homepage "http://www.proxysql.com/"
-  url "https://github.com/sysown/proxysql/archive/v1.4.9.tar.gz"
-  sha256 "28ee75735716ab2e882b377466f37f5836ce108cfcfe4cf36f31574f81cce401"
+  url "https://github.com/sysown/proxysql/archive/v1.4.10.tar.gz"
+  sha256 "29020cba75b778ef45b06c5469ee5930ce80afbd0290a112d8c2a6652b4c8a2e"
 
   # Build dependencies listed here: https://github.com/sysown/proxysql/blob/master/INSTALL.md
   depends_on "automake" => :build
   depends_on "cmake" => :build
   depends_on "make" => :build
   depends_on "mysql@5.6" => :test
-  depends_on "curl"
   depends_on "openssl"
-
-  # https://github.com/sysown/proxysql/pull/1564
-  # TODO when the 1.4.10 release is cut, this formula should be updated and
-  # this patch should be removed.
-  patch do
-    url "https://github.com/sysown/proxysql/compare/v1.4.10...zbentley:v1.4.10.diff?full_index=1"
-    sha256 "c0beccc67a834b5eb2b9d2d70ac28556eaf0268cc456453c97e326e68c894622"
-  end
-
-  # Fixed upstream, not yet released.
-  # TODO when the 1.4.10 release is cut, this formula should be updated
-  # and this patch should be removed.
-  patch do
-    url "https://github.com/sysown/proxysql/commit/9dab0eba12a717b738264d6928599034ea3ebe81.diff?full_index=1"
-  end
 
   def install
     system "make"

--- a/Formula/proxysql.rb
+++ b/Formula/proxysql.rb
@@ -11,7 +11,7 @@ class Proxysql < Formula
   depends_on "openssl"
 
   def install
-    system "make"
+    system "make", "GIT_VERSION=#{version}"
     # Currently, the Proxysql build system uses fixed paths for install locations.
     # See https://github.com/sysown/proxysql/blob/master/Makefile
     # The 'make install' target would need to be patched to support Homebrew.

--- a/Formula/proxysql.rb
+++ b/Formula/proxysql.rb
@@ -7,7 +7,6 @@ class Proxysql < Formula
   # Build dependencies listed here: https://github.com/sysown/proxysql/blob/master/INSTALL.md
   depends_on "automake" => :build
   depends_on "cmake" => :build
-  depends_on "make" => :build
   depends_on "mysql" => :test
   depends_on "openssl"
 

--- a/Formula/proxysql.rb
+++ b/Formula/proxysql.rb
@@ -1,8 +1,8 @@
 class Proxysql < Formula
   desc "High Performance Advanced Proxy for MySQL"
   homepage "http://www.proxysql.com/"
-  url "https://github.com/sysown/proxysql/archive/v1.4.11.tar.gz"
-  sha256 "9d34be2916e4b341820d2e9346a4697464e70d6ae1fb2a0761006299c96067c8"
+  url "https://github.com/sysown/proxysql/archive/v2.4.2.tar.gz"
+  sha256 "8e8a598f5d99f71dbba672c65a1102dd22a9a452e59dd0322bec4909b095eba0"
 
   # Build dependencies listed here: https://github.com/sysown/proxysql/blob/master/INSTALL.md
   depends_on "automake" => :build

--- a/Formula/proxysql.rb
+++ b/Formula/proxysql.rb
@@ -1,8 +1,8 @@
 class Proxysql < Formula
   desc "High Performance Advanced Proxy for MySQL"
   homepage "http://www.proxysql.com/"
-  url "https://github.com/sysown/proxysql/archive/v1.4.10.tar.gz"
-  sha256 "29020cba75b778ef45b06c5469ee5930ce80afbd0290a112d8c2a6652b4c8a2e"
+  url "https://github.com/sysown/proxysql/archive/v1.4.11.tar.gz"
+  sha256 "9d34be2916e4b341820d2e9346a4697464e70d6ae1fb2a0761006299c96067c8"
 
   # Build dependencies listed here: https://github.com/sysown/proxysql/blob/master/INSTALL.md
   depends_on "automake" => :build
@@ -19,9 +19,7 @@ class Proxysql < Formula
     bin.install "src/proxysql"
     etc.install "etc/proxysql.cnf"
     (var/"lib/proxysql").mkpath
-    inreplace etc/"proxysql.cnf" do |s|
-      s.gsub! %{datadir="/var/lib/proxysql"}, %{datadir="#{var}/lib/proxysql"}
-    end
+    inreplace etc/"proxysql.cnf", 'datadir="/var/lib/proxysql"', %Q(datadir="#{var}/lib/proxysql")
   end
 
   plist_options :manual => "proxysql"
@@ -59,7 +57,7 @@ class Proxysql < Formula
       output = pipe_output(
         "mysql -uadmin -padmin -S#{testpath}/admin.sock --default-auth=mysql_native_password",
         "select * from stats.stats_mysql_global",
-        0
+        0,
       )
       assert_match /ProxySQL_Uptime\s+[1-9]\d*/, output
     ensure

--- a/Formula/proxysql.rb
+++ b/Formula/proxysql.rb
@@ -8,7 +8,7 @@ class Proxysql < Formula
   depends_on "automake" => :build
   depends_on "cmake" => :build
   depends_on "make" => :build
-  depends_on "mysql@5.6" => :test
+  depends_on "mysql" => :test
   depends_on "openssl"
 
   def install
@@ -27,8 +27,9 @@ class Proxysql < Formula
       exec "#{bin}/proxysql", "-S", "admin.sock"
     end
     begin
+      sleep 2
       # Sleep until the proxy is up (querying it prematurely causes a segfault), then check its uptime.
-      output = pipe_output("sleep 2; echo 'select * from stats.stats_mysql_global' | $(brew --prefix mysql@5.6)/bin/mysql -uadmin -padmin -S admin.sock")
+      output = pipe_output("mysql -uadmin -S admin.sock", "select * from stats.stats_mysql_global", 0)
       assert_match /ProxySQL_Uptime\s+[1-9]\d*/, output
     ensure
       Process.kill("TERM", background_proxysql)

--- a/Formula/proxysql.rb
+++ b/Formula/proxysql.rb
@@ -1,0 +1,1 @@
+/Users/zac.bentley/Desktop/proxysql.rb

--- a/Formula/proxysql.rb
+++ b/Formula/proxysql.rb
@@ -29,12 +29,10 @@ class Proxysql < Formula
 
   def install
     system "make"
-    # There's a 'make install' target, but since the installer does not have a
-    # configurable prefix, it writes outside of brew-managed directories. All
-    # it does is copy files, so rather than inreplace-ing the makefile, just
-    # do the install manually. Given the way the rest of the Proxysql build
-    # system works, this doesn't seem likely to change any time soon.
+    # Currently, the Proxysql build system uses fixed paths for install locations.
     # See https://github.com/sysown/proxysql/blob/master/Makefile
+    # The 'make install' target would need to be patched to support Homebrew.
+    # Configurable target locations are requested in https://github.com/sysown/proxysql/issues/1565
     bin.install "src/proxysql"
     etc.install "etc/proxysql.cnf"
   end

--- a/Formula/proxysql.rb
+++ b/Formula/proxysql.rb
@@ -23,19 +23,30 @@ class Proxysql < Formula
     inreplace etc/"proxysql.cnf" do |s|
       s.gsub! %{datadir="/var/lib/proxysql"}, %{datadir="#{var}/lib/proxysql"}
     end
+  end
 
-    
-    if not (var/"lib/proxysql/proxysql.db").exist?
-      # Create initial data files so the launchd service can start/stop.
-      # The --initial switch destroys data, so it can't be used in the plist.
-      begin
-        background_proxysql = fork do
-          exec "#{bin}/proxysql", "-f", "-c", "#{etc}/proxysql.cnf", "--initial"
-        end
-      ensure
-        Process.kill("INT", background_proxysql)
-      end
-    end
+  plist_options :manual => "proxysql"
+
+  def plist; <<~EOS
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+    <plist version="1.0">
+      <dict>
+        <key>Label</key>
+        <string>#{plist_name}</string>
+        <key>ProgramArguments</key>
+        <array>
+          <string>#{bin}/proxysql</string>
+          <string>--foreground</string>
+          <string>--config</string>
+          <string>#{etc}/proxysql.cnf</string>
+        </array>
+        <key>RunAtLoad</key>
+        <true/>
+      </dict>
+    </plist>
+  EOS
   end
 
   test do

--- a/Formula/proxysql.rb
+++ b/Formula/proxysql.rb
@@ -1,1 +1,45 @@
-/Users/zac.bentley/Desktop/proxysql.rb
+class Proxysql < Formula
+  desc "General-purpose data compression with high compression ratio"
+  homepage "http://www.proxysql.com/"
+  url "https://github.com/sysown/proxysql/archive/v1.4.9.tar.gz"
+  # mirror "https://tukaani.org/xz/xz-5.2.4.tar.gz"
+  sha256 "28ee75735716ab2e882b377466f37f5836ce108cfcfe4cf36f31574f81cce401"
+
+  # Build dependencies listed here: https://github.com/sysown/proxysql/blob/master/INSTALL.md
+  depends_on "automake" => :build
+  depends_on "cmake" => :build
+  depends_on "make" => :build
+  depends_on "curl"
+  depends_on "openssl"
+
+  # https://github.com/sysown/proxysql/pull/1564
+  # TODO when the 1.4.10 release is cut, this formula should be updated and
+  # this patch should be removed.
+  patch do
+    url "https://github.com/sysown/proxysql/compare/v1.4.10...zbentley:v1.4.10.diff?full_index=1"
+    sha256 "c0beccc67a834b5eb2b9d2d70ac28556eaf0268cc456453c97e326e68c894622"
+  end
+
+  # Fixed upstream, not yet released.
+  # TODO when the 1.4.10 release is cut, this formula should be updated
+  # and this patch should be removed.
+  patch do
+    url "https://github.com/sysown/proxysql/commit/9dab0eba12a717b738264d6928599034ea3ebe81.diff?full_index=1"
+  end
+
+  def install
+    system "make"
+    # There's a 'make install' target, but since the installer does not have a
+    # configurable prefix, it writes outside of brew-managed directories. All
+    # it does is copy files, so rather than inreplace-ing the makefile, just
+    # do the install manually. Given the way the rest of the Proxysql build
+    # system works, this doesn't seem likely to change any time soon.
+    # See https://github.com/sysown/proxysql/blob/master/Makefile
+    bin.install "src/proxysql"
+    etc.install "etc/proxysql.cnf"
+  end
+
+  test do
+    system bin/"proxysql", "--help"
+  end
+end


### PR DESCRIPTION
Add formula for Proxysql (sysown/proxysql) with a few patches
to support the most recent release, all of which are either fixed
or pending-apporoval in an upcoming release.

Imported commits from:
- https://github.com/Homebrew/homebrew-core/pull/29220/commits

refs:
- https://github.com/sysown/proxysql/issues/3922